### PR TITLE
Add ability to test conferences easily in dev

### DIFF
--- a/scripts/create_fakes.py
+++ b/scripts/create_fakes.py
@@ -267,10 +267,11 @@ def parse_args():
     parser.add_argument('-p', '--privacy', dest="privacy", type=str, default='private', choices=['public', 'private'])
     parser.add_argument('-n', '--name', dest='name', type=str, default=None)
     parser.add_argument('-t', '--tags', dest='n_tags', type=int, default=5)
+    parser.add_argument('--presentation', dest='presentation_name', type=str, default=None)
     return parser.parse_args()
 
 
-def create_fake_project(creator, n_users, privacy, n_components, name, n_tags):
+def create_fake_project(creator, n_users, privacy, n_components, name, n_tags, presentation_name):
     auth = Auth(user=creator)
     project_title = name if name else fake.science_sentence()
     project = ProjectFactory.build(title=project_title, description=fake.science_paragraph(), creator=creator)
@@ -279,9 +280,13 @@ def create_fake_project(creator, n_users, privacy, n_components, name, n_tags):
         contrib = create_fake_user()
         project.add_contributor(contrib, auth=auth)
     for _ in range(n_components):
-        NodeFactory(project=project, title=fake.science_sentence(), description=fake.science_paragraph(), creator=creator)
+        NodeFactory(project=project, title=fake.science_sentence(), description=fake.science_paragraph(),
+                    creator=creator)
     for _ in range(n_tags):
         project.add_tag(fake.science_word(), auth=auth)
+    if presentation_name is not None:
+        project.add_tag(presentation_name, auth=auth)
+        project.add_tag('poster', auth=auth)
 
     project.save()
     logger.info('Created project: {0}'.format(project.title))
@@ -293,7 +298,8 @@ def main():
     creator = models.User.find(Q('username', 'eq', args.user))[0]
     for i in range(args.n_projects):
         name = args.name + str(i) if args.name else ''
-        create_fake_project(creator, args.n_users, args.privacy, args.n_components, name, args.n_tags)
+        create_fake_project(creator, args.n_users, args.privacy, args.n_components, name, args.n_tags,
+                            args.presentation_name)
     print('Created {n} fake projects.'.format(n=args.n_projects))
     sys.exit(0)
 

--- a/scripts/dev_populate_conferences.py
+++ b/scripts/dev_populate_conferences.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+import os
+import sys
+
+import argparse
+
+from modularodm import Q
+from modularodm.exceptions import ModularOdmException
+
+from framework.auth.core import User
+
+from website import settings
+from website.app import init_app
+from website.conferences.model import Conference
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Create conferences with a specified admin email.')
+    parser.add_argument('-u', '--user', dest='user', required=True)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    init_app(set_backends=True, routes=False)
+    populate_conferences(args.user)
+
+
+MEETING_DATA = {
+    'spsp2014': {
+        'name': 'SPSP 2014',
+        'info_url': None,
+        'logo_url': None,
+        'active': False,
+        'public_projects': True,
+    },
+    'asb2014': {
+        'name': 'ASB 2014',
+        'info_url': 'http://www.sebiologists.org/meetings/talks_posters.html',
+        'logo_url': None,
+        'active': False,
+        'public_projects': True,
+    },
+    'aps2014': {
+        'name': 'APS 2014',
+        'info_url': 'http://centerforopenscience.org/aps/',
+        'logo_url': '/static/img/2014_Convention_banner-with-APS_700px.jpg',
+        'active': False,
+        'public_projects': True,
+    },
+    'annopeer2014': {
+        'name': '#annopeer',
+        'info_url': None,
+        'logo_url': None,
+        'active': False,
+        'public_projects': True,
+    },
+    'cpa2014': {
+        'name': 'CPA 2014',
+        'info_url': None,
+        'logo_url': None,
+        'active': False,
+        'public_projects': True,
+    },
+    'filaments2014': {
+        'name': 'Filaments 2014',
+        'info_url': None,
+        'logo_url': 'https://science.nrao.edu/science/meetings/2014/'
+                    'filamentary-structure/images/filaments2014_660x178.png',
+        'active': False,
+        'public_projects': True,
+    },
+    'bitss2014': {
+        'name': 'BITSS Research Transparency Forum 2014',
+        'info_url': None,
+        'logo_url': os.path.join(
+            settings.STATIC_URL_PATH,
+            'img',
+            'conferences',
+            'bitss.jpg',
+        ),
+        'active': False,
+        'public_projects': True,
+    },
+    'spsp2015': {
+        'name': 'SPSP 2015',
+        'info_url': None,
+        'logo_url': 'http://spspmeeting.org/CMSPages/SPSPimages/spsp2015banner.jpg',
+        'active': True,
+    },
+    'aps2015': {
+        'name': 'APS 2015',
+        'info_url': None,
+        'logo_url': 'http://www.psychologicalscience.org/images/APS_2015_Banner_990x157.jpg',
+        'active': True,
+        'public_projects': True,
+    },
+    'icps2015': {
+        'name': 'ICPS 2015',
+        'info_url': None,
+        'logo_url': 'http://icps.psychologicalscience.org/wp-content/themes/deepblue/images/ICPS_Website-header_990px.jpg',
+        'active': True,
+        'public_projects': True,
+    },
+    'mpa2015': {
+        'name': 'MPA 2015',
+        'info_url': None,
+        'logo_url': 'http://www.midwesternpsych.org/resources/Pictures/MPA%20logo.jpg',
+        'active': True,
+        'public_projects': True,
+    },
+    'NCCC2015': {
+        'name': '2015 NC Cognition Conference',
+        'info_url': None,
+        'logo_url': None,
+        'active': True,
+        'public_projects': True,
+    },
+}
+
+
+def populate_conferences(email):
+    for meeting, attrs in MEETING_DATA.iteritems():
+        admin_objs = []
+        try:
+            user = User.find_one(Q('username', 'iexact', email))
+            admin_objs.append(user)
+        except ModularOdmException:
+            raise RuntimeError('Username {0!r} is not registered.'.format(email))
+        conf = Conference(
+            endpoint=meeting, admins=admin_objs, **attrs
+        )
+        try:
+            conf.save()
+        except ModularOdmException:
+            print('{0} Conference already exists. Updating existing record...'.format(meeting))
+            conf = Conference.find_one(Q('endpoint', 'eq', meeting))
+            for key, value in attrs.items():
+                setattr(conf, key, value)
+            conf.admins = admin_objs
+            conf.save()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Created a dev_populate_conferences script (based on the production version) that lets your specify an admin on the command line. Also modified the create_fakes script to create conference-tagged projects.

To run, first populate the conferences with the command:
python -m scripts.dev_populate_conferences -u your@email.here

(using a valid email address currently in use in your dev environment

Then:

python -m scripts.create_fakes -u your@email.here --nprojects 5 --nusers 1 --presentation NCCC2015 -p public

The presentation can be any of the active presentations in the dev_populate_conferences scripts. nprojects can be any number, but a conference needs at least 5 public projects to be visible. You could easily do a few hundred if you want to test the grid.

Active conferences include:
NCCC2015
mpa2015
icps2015
aps2015
spsp2015