### PR TITLE
[OSF style guideline] Finish dashboard, setting, get-start, and explore pages

### DIFF
--- a/website/static/css/explore.css
+++ b/website/static/css/explore.css
@@ -1,0 +1,9 @@
+.sidebar {
+  margin-top: 40px;
+}
+
+.sidebar ul {
+  border-radius: 5px;
+  padding: 5px;
+  border: 1px solid #cccccc;
+}

--- a/website/static/css/getstart.css
+++ b/website/static/css/getstart.css
@@ -1,0 +1,69 @@
+/* Getting Started */
+
+/* links */
+.gs-sidebar .nav a,
+.gs-sidebar .nav a:hover,
+.gs-sidebar .nav a:focus {
+
+    text-decoration: none;
+    background-color: transparent;
+}
+/* nested links */
+.gs-sidebar .nav .nav>li>a {
+    font-size: 12px;
+    padding: 4px 0 4px 15px;
+    opacity: 0.8;
+    font-weight: bold;
+}/* nested navs */
+.gs-sidebar .nav .nav {
+    display: none;
+}
+/* nested active navs */
+.gs-sidebar .nav .active .nav {
+    display: block;
+}
+/* nested link icons */
+.gs-sidebar .nav .nav>li>a i {
+    display: none;
+}
+/* nested active link icons */
+.gs-sidebar .nav .nav>.active>a i {
+    display: inline-block;
+}
+/* active & hover links */
+.gs-sidebar .nav>.active>a,
+.gs-sidebar .nav>li>a:hover,
+.gs-sidebar .nav>li>a:focus {
+    font-weight: bold;
+}
+/* nested active links */
+.gs-sidebar .nav .nav>.active>a,
+.gs-sidebar .nav .nav>.active:hover>a,
+.gs-sidebar .nav .nav>.active:focus>a {
+    font-weight: bold;
+}
+/* affixed sidebar */
+.gs-sidebar,
+.gs-sidebar.affix,
+.gs-sidebar.affix-top {
+    position: fixed;
+    top: 70px;
+}
+.affix-bottom {
+    position: relative;
+}
+
+/* embedded video */
+.gs-video {
+    margin-top: 25px;
+    margin-bottom: 25px;
+    margin-left: auto;
+    margin-right: auto;
+    border: solid 1px #ddd;
+}
+
+/* phase number counters */
+.gs-count {
+    margin-bottom: 20px;
+    margin-top: 50px;
+}

--- a/website/static/css/onboarding.css
+++ b/website/static/css/onboarding.css
@@ -71,10 +71,6 @@ ul.ob-widget-list {
 	display: block !important;
 }
 
-ul.nav.nav-tabs {
-    border-bottom:1px solid #eee
-}
-
 div.ob-dropzone-filename{
 	margin-top:10px;
 	font-family: "Lucida Console", Monaco, monospace;

--- a/website/static/css/onboarding.css
+++ b/website/static/css/onboarding.css
@@ -88,11 +88,6 @@ ul.ob-widget-list {
 	display: block !important;
 }
 
-.ob-tab-head {
-    padding-bottom: 5px;
-    margin: 25px 0 5px;
-}
-
 ul.nav.nav-tabs {
     border-bottom:1px solid #eee
 }

--- a/website/static/css/onboarding.css
+++ b/website/static/css/onboarding.css
@@ -26,14 +26,12 @@ ul.ob-widget-list {
 }
 
 .ob-dropzone-box {
-	border-radius:8px;
 	position:relative;
-	float:left;
 	height: 150px;
 	width: 100%;
 	font-size: 12px;
 	text-align: center;
-	border: solid 2px #ccc;
+	cursor: pointer;
 }
 
 .ob-clear-button{

--- a/website/static/css/onboarding.css
+++ b/website/static/css/onboarding.css
@@ -86,7 +86,6 @@ div.ob-dropzone-selected{
 
 img.ob-dropzone-icon{
 	height:90px;
-	margin-top:10px;
 	margin-left:auto;
 	margin-right:auto;
 }

--- a/website/static/css/onboarding.css
+++ b/website/static/css/onboarding.css
@@ -71,11 +71,6 @@ ul.ob-widget-list {
 	display: block !important;
 }
 
-div.ob-dropzone-filename{
-	margin-top:10px;
-	font-family: "Lucida Console", Monaco, monospace;
-}
-
 .ob-dropzone{
 	background-image: url("/static/img/upload.png");
 	background-repeat:no-repeat;

--- a/website/static/css/onboarding.css
+++ b/website/static/css/onboarding.css
@@ -12,16 +12,6 @@
 	height: 14px;
 }
 
-.typeAheadDisabled{
-    height: 110%;
-    font-size: 18px;
-    border: 2px solid #ccc;
-    -webkit-border-radius: 8px;
-    -moz-border-radius: 8px;
-    border-radius: 8px;
-    outline: none;
-}
-
 ul.ob-widget-list {
     padding: 0;
 }
@@ -77,7 +67,6 @@ ul.ob-widget-list {
 .ob-clear-button:hover{
 	cursor: pointer;
 }
-
 
 .projectSearchAddFile{
 	width:100%;

--- a/website/static/css/onboarding.css
+++ b/website/static/css/onboarding.css
@@ -66,10 +66,6 @@ ul.ob-widget-list {
 	cursor: pointer;
 }
 
-.projectSearchAddFile{
-	width:100%;
-}
-
 /*this exists to force sizing properly as typeahead tries desperately to overwrite it...*/
 .twitter-typeahead{
 	display: block !important;

--- a/website/static/css/profile.css
+++ b/website/static/css/profile.css
@@ -1,0 +1,45 @@
+.overflow {
+    word-wrap: break-word;
+    max-width: 100%;
+}
+
+span.edit-profile-settings {
+    display: block;
+    position: absolute;
+    bottom: 0;
+    right: 0;
+}
+
+div.profile-fullname{
+    display: block;
+    position: relative;
+    bottom: 0;
+}
+
+span#profileFullname{
+    position: absolute;
+    bottom: 0;
+    margin-bottom: 20px;
+}
+
+.pointer {cursor: pointer;}
+
+
+table.table.table-plain th, table.table.table-plain td {
+  text-align: left;
+  border-top: 0px solid #ddd;
+}
+
+.page-header {
+    overflow: hidden;
+}
+
+/* Profile gravatar
+-------------------------------------------------- */
+.profile-avatar{
+    margin-right:.5em;
+}
+#profile-gravatar{
+    width:70px;
+    height:70px;
+}

--- a/website/static/css/profile.css
+++ b/website/static/css/profile.css
@@ -24,7 +24,6 @@ span#profileFullname{
 
 .pointer {cursor: pointer;}
 
-
 table.table.table-plain th, table.table.table-plain td {
   text-align: left;
   border-top: 0px solid #ddd;
@@ -36,9 +35,6 @@ table.table.table-plain th, table.table.table-plain td {
 
 /* Profile gravatar
 -------------------------------------------------- */
-.profile-avatar{
-    margin-right:.5em;
-}
 #profile-gravatar{
     width:70px;
     height:70px;

--- a/website/static/css/setting.css
+++ b/website/static/css/setting.css
@@ -1,0 +1,4 @@
+#accountSettings .panel-title {
+  display: inline-block;
+  float: none;
+}

--- a/website/static/css/setting.css
+++ b/website/static/css/setting.css
@@ -1,4 +1,42 @@
-#accountSettings .panel-title {
+#accountSettings .panel-title, 
+#selectAddons .panel-title, 
+#selectLists .panel-title,
+#selectNotificationRefTab .panel-title,
+#configureAddons .panel-title{
   display: inline-block;
   float: none;
 }
+
+/* Minimal Treebeard for Configure Notifications in project and user settings */
+.osf-treebeard-minimal #tb-tbody {
+    border: none;
+    max-height: 500px;
+    height: inherit;
+    margin-top: 10px;
+}
+.osf-treebeard-minimal .tb-row {
+    padding-left: 10px;
+}
+
+.osf-treebeard-minimal .tb-row-titles {
+    border: none;
+}
+.osf-treebeard-minimal .tb-td {
+    padding-top: 4px;
+}
+.osf-treebeard-minimal .title-text {
+    line-height: 25px;
+}
+.osf-treebeard-minimal .tb-head {
+    display: none;
+}
+
+.osf-treebeard-minimal .form-control {
+    height: 26px;
+    padding: 0px;
+}
+
+.tb-no-icon .tb-expand-icon-holder {
+    width : 0;
+}
+

--- a/website/static/css/setting.css
+++ b/website/static/css/setting.css
@@ -1,12 +1,3 @@
-#accountSettings .panel-title, 
-#selectAddons .panel-title, 
-#selectLists .panel-title,
-#selectNotificationRefTab .panel-title,
-#configureAddons .panel-title{
-  display: inline-block;
-  float: none;
-}
-
 /* Minimal Treebeard for Configure Notifications in project and user settings */
 .osf-treebeard-minimal #tb-tbody {
     border: none;

--- a/website/static/js/pages/base-page.js
+++ b/website/static/js/pages/base-page.js
@@ -12,6 +12,12 @@ require('../../../../node_modules/osf-style/css/base.css');
 require('../../css/style.css');
 require('font-awesome-webpack');
 
+// for explore tab
+require('../../css/explore.css');
+
+// for help tab
+require('../../css/getstart.css');
+
 var $ = require('jquery');
 require('jquery.cookie');
 

--- a/website/static/js/pages/notifications-config-page.js
+++ b/website/static/js/pages/notifications-config-page.js
@@ -1,5 +1,7 @@
 var $ = require('jquery');
 
+require('../../css/setting.css');
+
 // initialize view model for configuring mailchimp subscriptions
 var NotificationsConfig =  require('../notificationsConfig.js');
 new NotificationsConfig('#selectLists', window.contextVars.mailingList);

--- a/website/static/js/pages/profile-account-settings-page.js
+++ b/website/static/js/pages/profile-account-settings-page.js
@@ -1,4 +1,5 @@
 'use strict';
+require('../../css/setting.css');
 
 var $ = require('jquery');
 var $osf = require('js/osfHelpers.js');

--- a/website/static/js/pages/profile-page.js
+++ b/website/static/js/pages/profile-page.js
@@ -7,6 +7,7 @@
 var profile = require('../profile.js'); // Social, Job, Education classes
 require('../project.js'); // Needed for nodelists to work
 require('../logFeed.js'); // Needed for nodelists to work
+require('../../css/profile.css');
 
 var ctx = window.contextVars;
 // Instantiate all the profile modules

--- a/website/static/js/pages/profile-settings-addons-page.js
+++ b/website/static/js/pages/profile-settings-addons-page.js
@@ -1,5 +1,7 @@
 'use strict';
 require('css/user-addon-settings.css');
+require('../../css/setting.css');
+
 var $ = require('jquery');
 var ko = require('knockout');
 var bootbox = require('bootbox');

--- a/website/templates/components/dashboard_templates.mako
+++ b/website/templates/components/dashboard_templates.mako
@@ -95,7 +95,7 @@
 
                 <!-- File queue display -->
                 <div data-bind="visible: !enableUpload()" class="ob-dropzone-selected ob-dropzone-box osf-box box-round box-lt pull-left">
-                    <img data-bind="attr: {src: iconSrc()}" class="ob-dropzone-icon" alt="File icon">
+                    <img data-bind="attr: {src: iconSrc()}" class="ob-dropzone-icon m-t-sm" alt="File icon">
                     <div data-bind="text: filename" class="m-t-sm"></div>
                     <progress
                         data-bind="attr: {value: progress()}, visible: showProgress()"

--- a/website/templates/components/dashboard_templates.mako
+++ b/website/templates/components/dashboard_templates.mako
@@ -96,7 +96,7 @@
                 <!-- File queue display -->
                 <div data-bind="visible: !enableUpload()" class="ob-dropzone-selected ob-dropzone-box osf-box box-round box-lt pull-left">
                     <img data-bind="attr: {src: iconSrc()}" class="ob-dropzone-icon" alt="File icon">
-                    <div data-bind="text: filename" class="ob-dropzone-filename"></div>
+                    <div data-bind="text: filename" class="m-t-sm"></div>
                     <progress
                         data-bind="attr: {value: progress()}, visible: showProgress()"
                             class="ob-upload-progress" max="100"></progress>

--- a/website/templates/components/dashboard_templates.mako
+++ b/website/templates/components/dashboard_templates.mako
@@ -91,10 +91,10 @@
                 <h4>1. Drop file (or click below)</h4>
 
                 <!-- Dropzone -->
-                <div data-bind="click: clearMessages(), visible: enableUpload()" id="obDropzone" class="ob-dropzone ob-dropzone-box pull-left"></div>
+                <div data-bind="click: clearMessages(), visible: enableUpload()" id="obDropzone" class="ob-dropzone ob-dropzone-box osf-box box-round box-lt pull-left"></div>
 
                 <!-- File queue display -->
-                <div data-bind="visible: !enableUpload()" class="ob-dropzone-selected ob-dropzone-box pull-left">
+                <div data-bind="visible: !enableUpload()" class="ob-dropzone-selected ob-dropzone-box osf-box box-round box-lt pull-left">
                     <img data-bind="attr: {src: iconSrc()}" class="ob-dropzone-icon" alt="File icon">
                     <div data-bind="text: filename" class="ob-dropzone-filename"></div>
                     <progress

--- a/website/templates/dashboard.mako
+++ b/website/templates/dashboard.mako
@@ -20,7 +20,7 @@
     ## Knockout componenet templates
     <%include file="components/dashboard_templates.mako"/>
     <div class="col-sm-5">
-        <div class="ob-tab-head" id="obTabHead">
+        <div class="p-b-xs m-t-lg m-b-xs" id="obTabHead">
             <ul class="nav nav-tabs" role="tablist">
             <li class="active"><a href="#quicktasks" role="tab" data-toggle="tab">Quick Tasks</a></li>
             <li><a href="#watchlist" role="tab" data-toggle="tab">Watchlist</a></li>

--- a/website/templates/dashboard.mako
+++ b/website/templates/dashboard.mako
@@ -31,7 +31,7 @@
 
         </div><!-- end #obTabHead -->
         <div class="tab-content" >
-            <div class="tab-pane active" id="quicktasks">
+            <div class="m-t-md tab-pane active" id="quicktasks">
                 <ul class="ob-widget-list"> <!-- start onboarding -->
                     <div id="obGoToProject">
                         <osf-ob-goto params="data: nodes"></osf-ob-goto>
@@ -64,10 +64,10 @@
                     </div>
                     % endif
                 </ul> <!-- end onboarding -->
-            </div><!-- end .tab-pane -->
-            <div class="tab-pane" id="watchlist">
+            </div>
+            <div class="m-t-md tab-pane" id="watchlist">
                 <%include file="log_list.mako" args="scripted=False"/>
-            </div><!-- end tab-pane -->
+            </div>
             ## %if 'badges' in addons_enabled:
                 ## <%include file="dashboard_badges.mako"/>
             ## %endif

--- a/website/templates/include/profile/jobs.mako
+++ b/website/templates/include/profile/jobs.mako
@@ -101,7 +101,7 @@
                 </a>
             </div>
 
-            <div class="padded">
+            <div class="p-t-lg p-b-lg">
 
                 <button
                         type="button"

--- a/website/templates/include/profile/names.mako
+++ b/website/templates/include/profile/names.mako
@@ -60,7 +60,7 @@
             </tbody>
         </table>
 
-        <div class="padded">
+        <div class="p-t-lg p-b-lg">
 
             <button
                     type="button"

--- a/website/templates/include/profile/schools.mako
+++ b/website/templates/include/profile/schools.mako
@@ -101,7 +101,7 @@
                 </a>
             </div>
 
-            <div class="padded">
+            <div class="p-t-lg p-b-lg">
 
                 <button
                         type="button"

--- a/website/templates/include/profile/social.mako
+++ b/website/templates/include/profile/social.mako
@@ -79,7 +79,7 @@
                 </div>
             </div>
 
-            <div class="padded">
+            <div class="p-t-lg p-b-lg">
 
                 <button
                         type="button"

--- a/website/templates/profile.mako
+++ b/website/templates/profile.mako
@@ -18,7 +18,7 @@
 
 <div class="page-header">
     <div class="profile-fullname">
-        <span class="profile-avatar">
+        <span class="m-r-sm">
         % if user['is_profile']:
             <a href="#changeAvatarModal" data-toggle="modal"><img id='profile-gravatar' src="${profile['gravatar_url']}"
                     rel="tooltip" title="Click to change avatar"/></a>

--- a/website/templates/profile.mako
+++ b/website/templates/profile.mako
@@ -70,15 +70,15 @@
 
         <div class="tab-content" id="containDrag">
 
-            <div class="tab-pane active" id="social">
+            <div class="m-t-md tab-pane active" id="social">
                 <div data-bind="template: {name: 'profileSocial'}"></div>
             </div>
 
-            <div class="tab-pane" id="jobs">
+            <div class="m-t-md tab-pane" id="jobs">
                 <div data-bind="template: {name: 'profileJobs'}"></div>
             </div>
 
-            <div class="tab-pane" id="schools">
+            <div class="m-t-md tab-pane" id="schools">
                 <div data-bind="template: {name: 'profileSchools'}"></div>
             </div>
 

--- a/website/templates/profile/account.mako
+++ b/website/templates/profile/account.mako
@@ -20,7 +20,7 @@
             </div>
             <div class="col-md-6">
                 <div id="connectedEmails" class="panel panel-default scripted">
-                    <div class="panel-heading"><h3 class="panel-title">Connected Emails</h3></div>
+                    <div class="panel-heading clearfix"><h3 class="panel-title">Connected Emails</h3></div>
                     <div class="panel-body">
                         <table class="table">
                             <thead>
@@ -83,7 +83,7 @@
                     </div>
                 </div>
                 <div id="changePassword" class="panel panel-default">
-                    <div class="panel-heading"><h3 class="panel-title">Change Password</h3></div>
+                    <div class="panel-heading clearfix"><h3 class="panel-title">Change Password</h3></div>
                     <div class="panel-body">
                         <form id="changePasswordForm" role="form" action="${ web_url_for('user_account_password') }" method="post">
                             <div class="form-group">
@@ -103,14 +103,14 @@
                     </div>
                 </div>
                 <div id="exportAccount" class="panel panel-default">
-                    <div class="panel-heading"><h3 class="panel-title">Export Account Data</h3></div>
+                    <div class="panel-heading clearfix"><h3 class="panel-title">Export Account Data</h3></div>
                     <div class="panel-body">
                         <p>Exporting your account data allows you to keep a permanent copy of the current state of your account. Keeping a copy of your account data can provide peace of mind or assist in transferring your information to another provider.</p>
                         <a class="btn btn-default" data-bind="click: submit, css: success() === true ? 'disabled' : ''">Request Export</a>
                     </div>
                 </div>
                 <div id="deactivateAccount" class="panel panel-default">
-                    <div class="panel-heading"><h3 class="panel-title">Deactivate Account</h3></div>
+                    <div class="panel-heading clearfix"><h3 class="panel-title">Deactivate Account</h3></div>
                     <div class="panel-body">
                         <p class="alert alert-warning"><strong>Warning:</strong> This action is irreversible.</p>
                         <p>Deactivating your account will remove you from all public projects to which you are a contributor. Your account will no longer be associated with OSF projects, and your work on the OSF will be inaccessible.</p>

--- a/website/templates/profile/addons.mako
+++ b/website/templates/profile/addons.mako
@@ -22,7 +22,7 @@
     <div class="col-sm-9 col-md-7">
 
         <div id="selectAddons" class="panel panel-default">
-            <div class="panel-heading"><h3 class="panel-title">Select Add-ons</h3></div>
+            <div class="panel-heading clearfix"><h3 class="panel-title">Select Add-ons</h3></div>
             <div class="panel-body">
 
                 <form id="selectAddonsForm">
@@ -67,7 +67,7 @@
         </div>
         % if addon_enabled_settings:
             <div id="configureAddons" class="panel panel-default">
-                <div class="panel-heading"><h3 class="panel-title">Configure Add-ons</h3></div>
+                <div class="panel-heading clearfix"><h3 class="panel-title">Configure Add-ons</h3></div>
                 <div class="panel-body">
 
                     % for name in addon_enabled_settings:

--- a/website/templates/profile/notifications.mako
+++ b/website/templates/profile/notifications.mako
@@ -20,7 +20,7 @@
 
     <div class="col-md-6">
         <div class="panel panel-default scripted" id="selectLists">
-            <div class="panel-heading"><h3 class="panel-title">Configure Email Preferences</h3></div>
+            <div class="panel-heading clearfix"><h3 class="panel-title">Configure Email Preferences</h3></div>
             <div class="panel-body">
                  <h3>Emails</h3>
                     </br>
@@ -46,8 +46,8 @@
                     <div data-bind="html: message, attr: {class: messageClass}"></div>
             </div><!--view model scope ends -->
         </div>
-        <div class="panel panel-default" id="selectNotificationRefTab">
-            <div class="panel-heading"><h3 class="panel-title">Configure Notification Preferences</h3></div>
+        <div class="panel panel-default">
+            <div class="panel-heading clearfix"><h3 class="panel-title">Configure Notification Preferences</h3></div>
                 <form id="selectNotifications" class="osf-treebeard-minimal">
                     <div id="grid">
                             <div class="notifications-loading"> <i class="fa fa-spinner notifications-spin"></i> <p class="m-t-sm fg-load-message"> Loading notification settings...  </p> </div>

--- a/website/templates/profile/notifications.mako
+++ b/website/templates/profile/notifications.mako
@@ -32,7 +32,7 @@
                             <label data-bind="text: list"></label>
                             <p class="text-muted" style="padding-left: 15px">Receive general notifications about the OSF every 2-3 weeks.</p>
                         </div>
-                        <div class="padded">
+                        <div class="p-t-lg p-b-lg">
                         <button
                             type="submit"
                             class="btn btn-success"

--- a/website/templates/profile/notifications.mako
+++ b/website/templates/profile/notifications.mako
@@ -46,7 +46,7 @@
                     <div data-bind="html: message, attr: {class: messageClass}"></div>
             </div><!--view model scope ends -->
         </div>
-        <div class="panel panel-default">
+        <div class="panel panel-default" id="selectNotificationRefTab">
             <div class="panel-heading"><h3 class="panel-title">Configure Notification Preferences</h3></div>
                 <form id="selectNotifications" class="osf-treebeard-minimal">
                     <div id="grid">

--- a/website/templates/profile/settings.mako
+++ b/website/templates/profile/settings.mako
@@ -42,19 +42,19 @@
 
             <div class="tab-content" id="containDrag">
 
-                <div class="tab-pane active" id="names">
+                <div class="m-t-md tab-pane active" id="names">
                     <div data-bind="template: {name: 'profileName'}"></div>
                 </div>
 
-                <div class="tab-pane" id="social">
+                <div class="m-t-md tab-pane" id="social">
                     <div data-bind="template: {name: 'profileSocial'}"></div>
                 </div>
 
-                <div class="tab-pane" id="jobs">
+                <div class="m-t-md tab-pane" id="jobs">
                     <div data-bind="template: {name: 'profileJobs'}"></div>
                 </div>
 
-                <div class="tab-pane" id="schools">
+                <div class="m-t-md tab-pane" id="schools">
                     <div data-bind="template: {name: 'profileSchools'}"></div>
                 </div>
 


### PR DESCRIPTION
### Changes
1)  Clear unused code in onboard.css

2)  Finish dashboard, setting, get-start, and explore pages
* explore.css -- for all the pages under explore tab
* getstart.css -- for get-start page
* profile.css -- for profile page
* setting.css -- for account setting page

### Side effects
Apply customized panel-title class in setting pages. When adding new penal, we also need update setting.css 

### TO DO:
* Log-in page
* Search bar input
* .....