### PR TITLE
Make Spinner Centered and Replace bootbox with modal in osf style guideline

### DIFF
--- a/website/static/js/navbarControl.js
+++ b/website/static/js/navbarControl.js
@@ -33,22 +33,7 @@ var NavbarViewModel = function() {
             $('#searchPageFullBar').focus();
         }
     };
-
-    self.help = function() {
-        bootbox.dialog({
-            title: 'Search help',
-            message: '<h4>Queries</h4>'+
-                '<p>Search uses the <a href="http://extensions.xwiki.org/xwiki/bin/view/Extension/Search+Application+Query+Syntax">Lucene search syntax</a>. ' +
-                'This gives you many options, but can be very simple as well. ' +
-                'Examples of valid searches include:' +
-                '<ul><li><a href="/search/?q=repro*">repro*</a></li>' +
-                '<li><a href="/search/?q=brian+AND+title%3Amany">brian AND title:many</a></li>' +
-                '<li><a href="/search/?q=tags%3A%28psychology%29">tags:(psychology)</a></li></ul>' +
-                '</p>'
-        });
-    };
-
-
+    
     self.submit = function() {
         $('#searchPageFullBar').blur().focus();
        if(self.query() !== ''){

--- a/website/templates/project/addon/citations_widget.mako
+++ b/website/templates/project/addon/citations_widget.mako
@@ -10,7 +10,7 @@ window.contextVars = $.extend(true, {}, window.contextVars, {
     <input id="${short_name}StyleSelect" type="hidden" />
 </div>
 <div id="${short_name}Widget" class="citation-widget">
-        <div class="fangorn-loading">
+        <div class="spinner-loading-wrapper">
             <div class="logo-spin text-center"><img src="/static/img/logo_spin.png" alt="loader"> </div>
             <p class="m-t-sm fg-load-message"> Loading citations...</p>
         </div>

--- a/website/templates/project/files.mako
+++ b/website/templates/project/files.mako
@@ -6,7 +6,7 @@
 </div>
 
 <div id="treeGrid">
-	<div class="fangorn-loading"> 
+	<div class="spinner-loading-wrapper">
 		<div class="logo-spin text-center"><img src="/static/img/logo_spin.png" alt="loader"> </div> 
 		<p class="m-t-sm fg-load-message"> Loading files...  </p> 
 	</div>

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -189,7 +189,7 @@
             </div>
             <div class="panel-body">
                 <div id="treeGrid">
-                    <div class="fangorn-loading">
+                    <div class="spinner-loading-wrapper">
                         <div class="logo-spin text-center"><img src="/static/img/logo_spin.png" alt="loader"> </div> 
                          <p class="m-t-sm fg-load-message"> Loading files...  </p>
                     </div>

--- a/website/templates/project/view_file.mako
+++ b/website/templates/project/view_file.mako
@@ -31,7 +31,7 @@
 
       <div class="osf-panel-body osf-panel-body-flex file-page reset-height">
         <div id="grid">
-          <div class="fangorn-loading">
+          <div class="spinner-loading-wrapper">
             <div class="logo-spin text-center"><img src="/static/img/logo_spin.png" alt="loader"> </div>
             <p class="m-t-sm fg-load-message"> Loading files...  </p>
           </div>

--- a/website/templates/search_bar.mako
+++ b/website/templates/search_bar.mako
@@ -1,3 +1,4 @@
+
 <div class="osf-search" data-bind="fadeVisible: showSearch" style="display: none">
     <div class="container">
         <div class="row">
@@ -7,12 +8,13 @@
                     <label id="searchBarLabel" class="search-label-placeholder" for="search-placeholder">Search</label>
                     <span class="input-group-btn">
                         <button type=button class="btn osf-search-btn" data-bind="click: submit"><i class="fa fa-circle-arrow-right fa-lg"></i></button>
-                        <button type=button class="btn osf-search-btn" data-bind="click: help"><i class="fa fa-question fa-lg"></i></button>
+                        <button type=button class="btn osf-search-btn" data-toggle="modal" data-target="#search-help-modal"><i class="fa fa-question fa-lg"></i></button>
                         <button type="button" class="btn osf-search-btn" data-bind="visible: showClose, click : toggleSearch"><i class="fa fa-times fa-lg"></i></button>
                     </span>
+
                 </form>
             </div>
         </div>
     </div>
 </div>
-
+<%include file="search_bar_help_modal.mako" />

--- a/website/templates/search_bar_help_modal.mako
+++ b/website/templates/search_bar_help_modal.mako
@@ -1,0 +1,22 @@
+<div class="modal fade" id="search-help-modal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true"></span>&times;</button>
+                    <h3 class="modal-title" >Search help</h3>
+                </div>
+                <div class="modal-body">
+                    <h4>Queries</h4>
+                    <p>Search uses the<a href="http://extensions.xwiki.org/xwiki/bin/view/Extension/Search+Application+Query+Syntax">Lucene search syntax</a>.This gives you many options, but can be very simple as well. Examples of valid searches include:</p>
+                    <ul>
+                        <li><a href="/search/?q=repro*">repro*</a></li>
+                        <li><a href="/search/?q=brian+AND+title%3Amany">brian AND title:many</a></li>
+                        <li><a href="/search/?q=tags%3A%28psychology%29">tags:(psychology)</a></li>
+                    </ul>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                </div>
+            </div>
+        </div>
+</div>


### PR DESCRIPTION
1) Fangorn-loading is not existing any more. To make spinner centered, spinner-loading-wrapper should be used here.
2) Replace the search bar help modal with the one from osf style guideline