### PR TITLE
Change url prefix depending on whether resource is a node or registration

### DIFF
--- a/website/static/js/project-organizer.js
+++ b/website/static/js/project-organizer.js
@@ -214,7 +214,8 @@ function _poResolveLazyLoad(item) {
     }
     if(node.relationships.children){
         //return node.relationships.children.links.related.href;
-        return $osf.apiV2Url('nodes/' + node.id + '/children/', {
+        var urlPrefix = node.attributes.registration ? 'registrations' : 'nodes';
+        return $osf.apiV2Url(urlPrefix + '/' + node.id + '/children/', {
             query : {
                 'related_counts' : 'children',
                 'embed' : 'contributors'


### PR DESCRIPTION
# Purpose

Not able to expand registrations.
# Changes

Makes change to method `_poResolveLazyLoad`, using `v2/nodes/...` endpoint if resource is a node and `v2/registrations...` if resource is a registration.
